### PR TITLE
feat(specs): rewrite spec of syntax

### DIFF
--- a/index.md
+++ b/index.md
@@ -64,24 +64,23 @@ debug issues across project boundaries.
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-1. commits MUST be prefixed with a type, which consists of a verb, `feat`, `fix`, etc.,
-   followed by a colon and a space.
-2. the type `feat` MUST be used when a commit adds a new feature to your application
+1. A *type* is a string token, e.g. `feat` or `fix`.
+2. A *scope* is a string token describing a section of the codebase enclosed in parenthesis, e.g. `(parser)`.
+3. A *description* is a short description of the pull request, e.g. `array parsing issue when multiple spaces were contained in string`.
+4. A commit message MUST start with a *type*.
+5. The *type* `feat` MUST be used when a commit adds a new feature to your application
   or library.
-3. the type `fix` MUST be used when a commit represents a bug fix for your application.
-4. an optional scope MAY be provided after a type. A scope is a phrase describing
-  a section of the codebase enclosed in parenthesis, e.g., `fix(parser):`
-5. A description MUST immediately follow the type/scope prefix.
-  The description is a short description of the pull request, e.g.,
-  _fix: array parsing issue when multiple spaces were contained in string._
-6. A longer commit body MAY be provided after the short description. The body MUST
+6. The *type* `fix` MUST be used when a commit represents a bug fix for your application.
+7. An optional *scope* MAY be provided immediately after the *type*. 
+8. A colon `:` and a space, followed by a *description* MUST be included after *scope*, when provided, or *type*, when *scope* is ommited.
+9. A longer commit *body* MAY be provided after the short description. The *body* then MUST
    begin one blank line after the description.
-7. A footer MAY be provided one blank line after the body. The footer SHOULD contain
+10. A *footer* MAY be provided one blank line after the *body*. The footer then SHOULD contain
    additional meta-information about the pull-request (such as the issues it fixes, e.g., `fixes #13, #5`).
-8. Breaking changes MUST be indicated at the very beginning of the footer or body section of a commit. A breaking change MUST consist of the uppercase text `BREAKING CHANGE`, followed by a colon and a space.
-9. A description MUST be provided after the `BREAKING CHANGE: `, describing what
-  has changed about the API, e.g., _BREAKING CHANGE: environment variables now take precedence over config files._
-10. types other than `feat` and `fix` MAY be used in your commit messages.
+11. Breaking changes MUST be indicated at the very beginning of the *footer* or *body* section of a commit. A breaking change MUST consist of the uppercase text `BREAKING CHANGE`, followed by a colon and a space.
+12. A description MUST be provided after the `BREAKING CHANGE: `, describing what
+  has changed about the API, e.g., `BREAKING CHANGE: environment variables now take precedence over config files.`
+13. Types other than `feat` and `fix` MAY be used in the commit message.
 
 ## Why Use Conventional Commits
 


### PR DESCRIPTION
The current spec has several formal ambiguities:
 * Point 1. does not (formally) allow scope.
 * Examples of scope and description include type.
 * `feat` is not a verb.
 * Unclear what ‘type/scope prefix’ is.
 
I tried to remove these and I hope this change achieves that.

Do you think it is OK? Is it readable?